### PR TITLE
Update Noriben.py

### DIFF
--- a/Noriben.py
+++ b/Noriben.py
@@ -1104,6 +1104,7 @@ def parse_csv(csv_file, report, timeline):
 
             elif field[3] == 'RegCreateKey' and field[5] == 'SUCCESS':
                 if not approvelist_scan(reg_approvelist, field):
+                    path = field[4]
                     log_debug('[*] RegCreateKey: {}'.format(path))
 
                     outputtext = '[RegCreateKey] {}:{} > {}'.format(field[1], field[2], field[4])


### PR DESCRIPTION
Added the line to set the variable 'path' before it is referenced.
- That code block is not called with the default Noriben execution.
- However, the code block is called when Noriben parses a PML file containing 'RegCreateKey' events.