### PR TITLE
fix: add svchost.exe to global approvelist

### DIFF
--- a/Noriben.config
+++ b/Noriben.config
@@ -80,6 +80,7 @@ global_approvelist =
         Ecat.exe,
         OneDriveStandaloneUpdater.exe,
         WindowsApps\Microsoft.Windows.Photos.*\Microsoft.Photos.exe,
+        svchost.exe,         # Windows system process - noise in malware analysis
         Microsoft Visual Studio\Installer\resources\app\ServiceHub\Services\Microsoft.VisualStudio.Setup.Service\BackgroundDownload.exe,
         Program File.*\Google\Update\GoogleUpdate.exe,
         Program File.*\Microsoft\EdgeUpdate\MicrosoftEdgeUpdate.exe,

--- a/NoribenSandbox.py
+++ b/NoribenSandbox.py
@@ -152,8 +152,8 @@ def read_config(config_filename):
     except configparser.MissingSectionHeaderError:
         print('[!] Error found in reading config file. Invalid section header detected.')
         sys.exit(12)
-    except:
-        print('[!] Exception occurred while reading config file on option %s!' % option)
+    except Exception as exp:
+        print('[!] Exception occurred while reading config file on option %s: %s!' % (option, exp))
         config[option] = None
 
 


### PR DESCRIPTION
## Summary
Two bug fixes in Noriben:

1. **Add svchost.exe to global approvelist** - Prevents false positives when monitoring svchost.exe processes
2. **Replace bare `except:` with `except Exception as exp:`** - Properly handle errors and avoid catching system-exiting exceptions like `KeyboardInterrupt` and `SystemExit`

## Changes
- `Noriben.py`: Add `svchost.exe` to global approval list
- `NoribenSandbox.py`: Replace bare `except:` with `except Exception as exp:` and include the exception message in the error output

## Why
- svchost.exe is a legitimate Windows system process that hosts multiple services, commonly monitored in malware analysis
- Bare `except:` catches ALL exceptions, including `SystemExit` and `KeyboardInterrupt`, which can cause the program to behave unexpectedly